### PR TITLE
feat: add config file validation and JSON schema

### DIFF
--- a/src/schemas/config.v1.schema.json
+++ b/src/schemas/config.v1.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://mpak.dev/schemas/config.v1.json",
+  "title": "mpak CLI Configuration v1",
+  "description": "Configuration file for the mpak CLI stored at ~/.mpak/config.json",
+  "type": "object",
+  "required": ["version", "lastUpdated"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0.0",
+      "description": "Configuration schema version"
+    },
+    "lastUpdated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of last configuration update"
+    },
+    "registryUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "Custom registry URL (overrides default https://api.mpak.dev)"
+    },
+    "packages": {
+      "type": "object",
+      "description": "Per-package configuration values (user_config)",
+      "additionalProperties": {
+        "type": "object",
+        "description": "Configuration key-value pairs for a specific package",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `ConfigCorruptedError` class for clear error reporting when config is invalid
- Add strict validation for `~/.mpak/config.json` that checks required fields, types, and rejects unknown fields
- Add JSON schema at `src/schemas/config.v1.schema.json` documenting the config format
- Add comprehensive test coverage for all validation paths

## Test plan

- [x] Tests pass (`npm run test:all`)
- [ ] Manual: corrupt config file and verify clear error message
- [x] Manual: add unknown field to config and verify rejection